### PR TITLE
Add pre commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: standard-readme
+  name: Standard Readme
+  description: Check README compliance with standard-readme spec
+  entry: standard-readme
+  language: node
+  files: '^README.md$'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "lint": "standard",
     "test": "standard && echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/RichardLitt/standard-readme-cli.git"
+  },
   "keywords": [
     "standard",
     "readme",


### PR DESCRIPTION
# Pull Request

_Migrated from https://github.com/RichardLitt/standard-readme-preset/pull/40_

## Description of Changes

- Added a [pre-commit](https://pre-commit.com/) hook for linting `README.md` files on-commit (via Git Hooks). Can also be used with [this](https://github.com/pre-commit/action) GitHub Action to enforce a passing check before merging. This also allows repo owners to define a single set of quality checks one time for both local development and the CI/CD pipeline.
- Added a `repository` block to satisfy npm warning