### PR TITLE
Update dependencies and fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ standard-readme
 
 - [@RichardLitt](https://github.com/RichardLitt)
 
-## Contribute
+## Contributing
 
 Please do! Open an issue, or file a PR.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "index.js",
   "scripts": {
     "lint": "standard",
-    "test": "standard && echo \"Error: no test specified\" && exit 1"
+    "test": "standard && node index.js && echo \"Error: no additional test specified\""
   },
   "repository": {
     "type": "git",
@@ -24,15 +24,14 @@
   "author": "Richard Littauer",
   "license": "MIT",
   "dependencies": {
-    "remark": "^7.0.1",
-    "remark-parse": "^3.0.1",
+    "remark": "^13.0.0",
     "standard-readme-preset": "^1.0.2",
     "to-vfile": "^2.1.1",
     "unified": "^6.1.3",
     "vfile-reporter": "^3.0.0"
   },
   "devDependencies": {
-    "standard": "^10.0.2"
+    "standard": "^16.0.4"
   },
   "coordinates": [
     52.5173012,


### PR DESCRIPTION
Npm reported a security warning on library remark-parse. I've update
remark to version 13, the next would require switching to ES modules.
Please create a new release to get rid of security warnings in projects
that use this script as dev-dependency.

To test functionality, the cli is now run against its own repository
(and it found a minor error :-)